### PR TITLE
Queue only those assets that were actually modified by webpack.

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,13 +65,15 @@ module.exports = function(options, wp, done) {
     var fs = compiler.outputFileSystem = new MemoryFileSystem();
     compiler.plugin('after-emit', function(compilation, callback) {
       Object.keys(compilation.assets).forEach(function(outname) {
-        var path = fs.join(compiler.outputPath, outname);
-        var contents = fs.readFileSync(path);
-        self.queue(new File({
-          base: compiler.outputPath,
-          path: path,
-          contents: contents,
-        }));
+        if (compilation.assets[outname].emitted) {
+          var path = fs.join(compiler.outputPath, outname);
+          var contents = fs.readFileSync(path);
+          self.queue(new File({
+            base: compiler.outputPath,
+            path: path,
+            contents: contents,
+          }));
+        }
       });
       callback();
     });


### PR DESCRIPTION
Do not queue assets that were not changed. Might save some time postprocessing assets that were not changed.
