### PR TITLE
Don't sent entry to undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function(options, wp, done) {
     entry.push(file.path);
   }, function() {
     var self = this;
-    if (entry.length < 2) entry = entry[0];
+    if (entry.length < 2) entry = entry[0] || entry;
     if (!options.entry) options.entry = entry;
     options.output = options.output || {};
     if (!options.output.path) options.output.path = process.cwd();


### PR DESCRIPTION
When there is nothing in  `entry` `entry[0]` sets `entry` to be undefined which breaks `gulp-webpack`:

```
/Users/bjorn/projects/polydamas/node_modules/gulp-webpack/index.js:47                  
    entry.push(file.path);                                                               
          ^                                                                              
TypeError: Cannot call method 'push' of undefined
```

This happened with the following config:

```
gulp.task('webpack',  function () {
  return gulp.src('demo/jsx/*.js')
      .pipe(webpack( require('./webpack.config.js') ))
      .pipe(gulp.dest('dist/'));
});
```

```
module.exports = {
  entry: "./demo/jsx/label.js",
  output: {
    filename: "./demo/js/label.js"
  },
  module: {
    loaders: [
      { test: /\.css$/, loader: "style!css" }
    ]
  }
};
```
