### PR TITLE
entry was undefined when using gulp-watch

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ module.exports = function(options, wp, done) {
   var entry = [];
 
   var stream = through(function(file) {
+    entry = entry || [];
     entry.push(file.path);
   }, function() {
     var self = this;


### PR DESCRIPTION
Crashed on entry.push(file.path);

Crash log:

```
C:\env1\node_modules\gulp-webpack\index.js:44
    entry.push(file.path);
          ^
TypeError: Cannot call method 'push' of undefined
    at Stream.self (C:\env1\node_modules\gulp-webpack\index.js:44:11)
    at Stream.stream.write (C:\env1\node_modules\gulp-webpack\node_modules\through\index.js:26:11)
    at write (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:605:24)
    at flow (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:614:7)
    at Transform.pipeOnReadable (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:646:5)
    at Transform.EventEmitter.emit (events.js:92:17)
    at emitReadable_ (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:430:10)
    at emitReadable (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:426:5)
    at readableAddChunk (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:187:9)
    at Transform.Readable.push (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:149:10)
    at Transform.push (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:145:32)
    at afterTransform (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:101:12)
    at TransformState.afterTransform (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:79:12)
    at Transform.noop [as _transform] (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\through2.js:8:3)
    at Transform._read (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:184:10)
    at Transform._write (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:172:12)
    at doWrite (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_writable.js:238:10)
    at writeOrBuffer (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_writable.js:228:5)
    at Transform.Writable.write (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_writable.js:195:11)
    at write (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:605:24)
    at flow (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:614:7)
    at Transform.pipeOnReadable (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:646:5)
    at Transform.EventEmitter.emit (events.js:92:17)
    at emitReadable_ (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:430:10)
    at emitReadable (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:426:5)
    at readableAddChunk (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:187:9)
    at Transform.Readable.push (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_readable.js:149:10)
    at Transform.push (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:145:32)
    at afterTransform (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:101:12)
    at TransformState.afterTransform (C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\through2\node_modules\readable-stream\lib\_stream_transform.js:79:12)
    at C:\env1\node_modules\gulp\node_modules\vinyl-fs\lib\src\getContents\bufferFile.js:12:5
    at evalmachine.<anonymous>:266:14
    at C:\env1\node_modules\gulp\node_modules\vinyl-fs\node_modules\graceful-fs\graceful-fs.js:102:5
    at Object.oncomplete (evalmachine.<anonymous>:107:15)
```
