### PR TITLE
Display an error message if there are no input files

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,10 +41,18 @@ module.exports = function(options, wp, done) {
   var entry = [];
 
   var stream = through(function(file) {
+    if (file.isNull()) return;
+
     entry = entry || [];
     entry.push(file.path);
   }, function() {
     var self = this;
+
+    if (entry.length == 0) {
+      gutil.log('gulp-webpack - No files given; aborting compilation');
+      return;
+    }
+
     if (entry.length < 2) entry = entry[0] || entry;
     if (!options.entry) options.entry = entry;
     options.output = options.output || {};


### PR DESCRIPTION
Show an error message when there are no input files, rather than crashing gulp.

Also makes gulp-webpack play nice with [gulp-newer](https://github.com/tschaub/gulp-newer)
