### PR TITLE
Updated README to reflect `watch` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,5 +122,5 @@ The above `named()` stream will add a `.named` property to the vinyl files passi
 * 0.1.0 - Initial release
 
 ## License
-Copyright (c) 2014 Kyle Robinson Young
+Copyright (c) 2014 Kyle Robinson Young  
 Licensed under the MIT license.


### PR DESCRIPTION
Given that most people use gulp-watch to watch for changes on _all_ files, many are not aware that by avoiding watch at the gulp level and pushing it onto the webpack config they can greatly increase their compilation time.  
