### PR TITLE
Avoid modifying options by reference

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var defaultStatsOptions = {
 };
 
 module.exports = function (options, wp, done) {
-  options = options || {};
+  options = clone(options) || {};
   if (typeof done !== 'function') {
     var callingDone = false;
     done = function (err, stats) {
@@ -160,3 +160,12 @@ Object.defineProperty(module.exports, 'webpack', {
     return require('webpack');
   }
 });
+
+function clone(source) {
+  var target = {};
+  Object.keys(source).forEach(function(key) {
+    target[key] = source[key];
+  });
+
+  return target;
+}


### PR DESCRIPTION
If you dynamically create a task like so:

```js
function build(module) {
  return gulp.src('src/' + module)
  .pipe(webpack(webpackConfig))
  .pipe(gulp.dest('public/' + module));
}

gulp.task('build-a', function() { return build('a.js'); });
gulp.task('build-b', function() { return build('b.js'); });
gulp.task('default', ['build-a', 'build-b']);
```

When running `gulp default`, [options.entry](https://github.com/shama/webpack-stream/blob/master/index.js#L91) would be `src/a.js` both times.

To avoid that, we make a shallow copy of `options` and modify that instead.