### PR TITLE
Resolves a bug where watch would break output.

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,9 +107,7 @@ module.exports = function (options, wp, done) {
       if (err) {
         self.emit('error', new gutil.PluginError('webpack-stream', err));
       }
-      if (!options.watch) {
-        self.queue(null);
-      }
+      self.queue(null);
       done(err, stats);
       if (options.watch && !options.quiet) {
         gutil.log('webpack is watching for changes');


### PR DESCRIPTION
For whatever reason, this conditional would break the output of the module. I have no idea why this was added, but removing it does fix the issue. I've verified that this line is the culprit by removing it altogether, and in that case the build always fails, whether watch is on or not.

Resolves #79