### PR TITLE
Add support for source maps

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var MemoryFileSystem = require('memory-fs');
 var through = require('through');
 var ProgressPlugin = require('webpack/lib/ProgressPlugin');
 var clone = require('lodash.clone');
+var applySourceMap = require('vinyl-sourcemaps-apply');
 
 var defaultStatsOptions = {
   colors: gutil.colors.supportsColor,
@@ -133,20 +134,36 @@ module.exports = function (options, wp, done) {
 
     var fs = compiler.outputFileSystem = new MemoryFileSystem();
     compiler.plugin('after-emit', function (compilation, callback) {
-      Object.keys(compilation.assets).forEach(function (outname) {
-        if (compilation.assets[outname].emitted) {
-          var path = fs.join(compiler.outputPath, outname);
-          if (path.indexOf('?') !== -1) {
-            path = path.split('?')[0];
+      var assetNames = Object.keys(compilation.assets);
+      assetNames
+        // Webpack emits the source map, but Gulp will read that for us
+        .filter(function (outname) {
+          return !/\.map$/.test(outname);
+        })
+        .forEach(function (outname) {
+          if (compilation.assets[outname].emitted) {
+            var path = fs.join(compiler.outputPath, outname);
+            if (path.indexOf('?') !== -1) {
+              path = path.split('?')[0];
+            }
+            var contents = fs.readFileSync(path);
+            var file = new File({
+              base: compiler.outputPath,
+              path: path,
+              // Remove the source map comment as Gulp will handle that
+              contents: new Buffer(contents.toString().replace(/\n\/\/#.*$/, ''))
+            });
+            var sourceMapPath = outname + '.map';
+            var hasSourceMap = assetNames.some(function (assetName) {
+              return assetName === sourceMapPath;
+            });
+            if (hasSourceMap) {
+              var sourceMap = JSON.parse(fs.readFileSync(fs.join(compiler.outputPath, sourceMapPath)));
+              applySourceMap(file, sourceMap);
+            }
+            self.queue(file);
           }
-          var contents = fs.readFileSync(path);
-          self.queue(new File({
-            base: compiler.outputPath,
-            path: path,
-            contents: contents
-          }));
-        }
-      });
+        });
       callback();
     });
   });

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "memory-fs": ">=0.2.0 <0.3.0-0",
     "through": ">=2.3.4 <2.4.0-0",
     "vinyl": ">=0.5.0 <0.6.0-0",
+    "vinyl-sourcemaps-apply": "^0.2.0",
     "webpack": ">=1.9.0 <2.0.0-0"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,22 @@ var named = require('vinyl-named');
 
 var base = path.resolve(__dirname, 'fixtures');
 
+test('source maps', function (t) {
+  t.plan(2);
+  var entry = fs.src('test/fixtures/entry.js');
+  var stream = webpack({
+    output: {
+      filename: 'bundle.js'
+    },
+    quiet: true,
+    devtool: 'source-map'
+  });
+  stream.on('data', function (file) {
+    t.ok(!!file.sourceMap, 'should have source map');
+  });
+  entry.pipe(stream);
+});
+
 test('streams output assets', function (t) {
   t.plan(3);
   var entry = fs.src('test/fixtures/entry.js');


### PR DESCRIPTION
Fixes #40

I was quite surprised that a project as mature as Webpack didn't have the tooling to support source maps with Gulp. :unamused: Source maps are essential!