### PR TITLE
Fix fonts passed through the stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ function prepareFile (fs, compiler, outname) {
   var file = new File({
     base: compiler.outputPath,
     path: path,
-    contents: new Buffer(contents.toString())
+    contents: contents
   });
   return file;
 }


### PR DESCRIPTION
This was the [pre 2.2.0](https://github.com/shama/webpack-stream/commit/08c045339561ab8f020953c9374f8544f6c8d21e#diff-168726dbe96b3ce427e7fedce31bb0bcL146) behaviour. I tested it locally and confirmed it fixes the broken fonts :smile: 

Closes #87 