### PR TITLE
Exit from function after self.emit('error', ...)

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,7 @@ module.exports = function (options, wp, done) {
     var compiler = webpack(config, function (err, stats) {
       if (err) {
         self.emit('error', new gutil.PluginError('webpack-stream', err));
+        return;
       }
       var jsonStats = stats.toJson() || {};
       var errors = jsonStats.errors || [];


### PR DESCRIPTION
About the issue #34 

When I try to handle error like this:

```javascript
gulp.task('webpack', function() {
    return gulp.src(config.sourceDir + '/js/index.js')
        .pipe(webpack(require('./webpack.config.js')))
        .on('error', function(err) {
            gutil.log('WEBPACK ERROR', err.message);
            this.emit('end');
        })
        .pipe(gulp.dest(config.destDir));
});
```

App crashes with this stdout:
```
var jsonStats = stats.toJson() || {};
                    ^
TypeError: Cannot read property 'toJson' of undefined
```

Problem is in [index.js#133](https://github.com/shama/webpack-stream/blob/master/index.js#L133).
It can be easily solved by adding `return;` after `self.emit()`:

```javascript
if (err) {
  self.emit('error', new gutil.PluginError('webpack-stream', err));
  return;
}
```

It will prevent trying to execute `stats.toJson()` since `stats` is `undefined` in case of error.