### PR TITLE
Fix error, in watch mode stat errors(in my case from ts-loader) webpa…

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,10 @@ module.exports = function (options, wp, done) {
           resultMessage += nextError.toString();
           return resultMessage;
         }, '');
-        self.emit('error', new gutil.PluginError('webpack-stream', errorMessage));
+
+        if (!options.watch) {
+          self.emit('error', new gutil.PluginError('webpack-stream', errorMessage));
+        }
       }
       if (!options.watch) {
         self.queue(null);


### PR DESCRIPTION
Fix error, in watch mode stat errors(in my case from ts-loader) webpack still watching, but pipes below breaks.

Related comments:
https://github.com/shama/webpack-stream/issues/34#issuecomment-220852780,
https://github.com/shama/webpack-stream/issues/18#issuecomment-220851827
