### PR TITLE
Fix TypeError when 'stats' are undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ module.exports = function (options, wp, done) {
       if (err) {
         self.emit('error', new gutil.PluginError('webpack-stream', err));
       }
-      var jsonStats = stats.toJson() || {};
+      var jsonStats = stats ? stats.toJson() || {} : {};
       var errors = jsonStats.errors || [];
       if (errors.length) {
         var errorMessage = errors.reduce(function (resultMessage, nextError) {


### PR DESCRIPTION
Before fixing this issue user gets message: "TypeError: Cannot read property 'toJson' of undefined" and a stack trace.

After adding proposed check user is getting regular gulp error message with sense.
