### PR TITLE
No error event on compilation error when watching

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,7 +139,11 @@ module.exports = function (options, wp, done) {
           resultMessage += nextError.toString();
           return resultMessage;
         }, '');
-        self.emit('error', new gutil.PluginError('webpack-stream', errorMessage));
+        var compilationError = new gutil.PluginError('webpack-stream', errorMessage);
+        if (!options.watch) {
+          self.emit('error', compilationError);
+        }
+        self.emit('compilation-error', compilationError);
       }
       if (!options.watch) {
         self.queue(null);


### PR DESCRIPTION
No `error` event should be emitted on a compilation error when watching, because node stops writing data after an `error` event. See https://github.com/shama/webpack-stream/issues/34#issuecomment-244534449 for a detailed description.

Instead, we can always safely emit a `compilation-error` event. This makes sure that others are still able listen for compilation errors. Additionally, when we are not in watch mode, we do emit an `error` event to keep the behavior the same and do not break backwards compatibility for non-watching tasks.
