### PR TITLE
Fix a bug: output.filename starts with / will raise error

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var gutil = require('gulp-util');
 var File = require('vinyl');
 var MemoryFileSystem = require('memory-fs');
+var nodePath = require('path');
 var through = require('through');
 var ProgressPlugin = require('webpack/lib/ProgressPlugin');
 var clone = require('lodash.clone');
@@ -213,7 +214,7 @@ function prepareFile (fs, compiler, outname) {
 
   var file = new File({
     base: compiler.outputPath,
-    path: path,
+    path: nodePath.join(compiler.outputPath, outname),
     contents: contents
   });
   return file;


### PR DESCRIPTION
 Memory-fs.join has a different behavior comparing to node's path.join when the non-first argument contains / or . And it'll cause a bug when filename contains / or (only webpack is all right).

 so, at least, we should use node's path.join when w'll interact with real fs.

renaesop/wepack-stream-issue#1
