### PR TITLE
Merge stream entries with webpack config entries.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var nodePath = require('path');
 var through = require('through');
 var ProgressPlugin = require('webpack/lib/ProgressPlugin');
 var clone = require('lodash.clone');
-var some = require('lodash.some');
 
 var defaultStatsOptions = {
   colors: gutil.colors.supportsColor,
@@ -80,8 +79,7 @@ module.exports = function (options, wp, done) {
       }
       entries[file.named].push(file.path);
     } else {
-      entry = entry || [];
-      entry.push(file.path);
+      entry = { main: file.path };
     }
   }, function () {
     var self = this;
@@ -100,7 +98,8 @@ module.exports = function (options, wp, done) {
         entry = entry[0] || entry;
       }
 
-      config.entry = config.entry || entry;
+      config.entry = Object.assign({}, config.entry, entry);
+      config.entry = Object.keys(config.entry).length === 0 ? [] : config.entry;
       config.output.path = config.output.path || process.cwd();
       config.output.filename = config.output.filename || '[hash].js';
       config.watch = options.watch;
@@ -197,14 +196,6 @@ module.exports = function (options, wp, done) {
       handleCompiler(compiler);
     }
   });
-
-  // If entry point manually specified, trigger that
-  var hasEntry = Array.isArray(config)
-    ? some(config, function (c) { return c.entry; })
-    : config.entry;
-  if (hasEntry) {
-    stream.end();
-  }
 
   return stream;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,33 @@ test('stream multiple entry points', function (t) {
   entries.pipe(named()).pipe(stream);
 });
 
+test('stream and config entry points', function (t) {
+  t.plan(3);
+  var entries = fs.src('test/fixtures/entry.js');
+  var stream = webpack({
+    config: {
+      entry: {
+        'two': path.join(base, 'anotherentrypoint.js')
+      }
+    },
+    quiet: true
+  });
+  stream.on('data', function (file) {
+    var basename = path.basename(file.path);
+    var contents = file.contents.toString();
+    switch (basename) {
+      case 'entry.js':
+        t.ok(/__webpack_require__/i.test(contents), 'should contain "__webpack_require__"');
+        t.ok(/var one = true;/i.test(contents), 'should contain "var one = true;"');
+        break;
+      case 'two.js':
+        t.ok(/var anotherentrypoint = true;/i.test(contents), 'should contain "var anotherentrypoint = true;"');
+        break;
+    }
+  });
+  entries.pipe(named()).pipe(stream);
+});
+
 test('empty input stream', function (t) {
   t.plan(1);
 


### PR DESCRIPTION
This pull request merges any entries in the stream with any entries defined in the config.

The specific use case I wish to support looks like this:

```js
const gulp = require( "gulp" );
const webpack = require( "webpack" );
const named = require( "vinyl-named" );
const gulpWebpack = require( "webpack-stream" );

gulp.src( [ "src/file1.js", "src/file2.js" ] )
    .pipe( named() )
    .pipe( gulpWebpack( {
        entry: {
            vendor: [ "vue", "axios" ]
        },
        plugins: [
            new webpack.optimize.CommonsChunkPlugin( {
                name: "vendor"
            } ),
            new webpack.optimize.CommonsChunkPlugin( {
                name: "runtime"
            } )
        ]
    } )
```

This will allow me to pass in the files in a stream, but still have my vendor chunk pulled out separately.  The biggest change made to this is that a single entry now gets the named `main` if there are no other entries or output options.

I also added a test that supports this use case.

Thanks for the great project!