### PR TITLE
If there is only one file for named entry, pass it directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,13 @@ module.exports = function (options, wp, done) {
       config.watch = !!options.watch;
 
       // Determine pipe'd in entry
-      if (Object.keys(entries).length > 0) {
+      var entriesNames = Object.keys(entries);
+      if (entriesNames.length > 0) {
+        entriesNames.forEach(function (entryName) {
+          if (entries[entryName].length === 1) {
+            entries[entryName] = entries[entryName][0];
+          }
+        });
         entry = entries;
         if (!config.output.filename) {
           // Better output default for multiple chunks

--- a/test/fixtures/subdirectory/entry.js
+++ b/test/fixtures/subdirectory/entry.js
@@ -1,0 +1,1 @@
+var subDirectoryEntry = true;

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,28 @@ test('stream multiple entry points', function (t) {
   entries.pipe(named()).pipe(stream);
 });
 
+test('stream multiple entry points, one with two files', function (t) {
+  t.plan(2);
+  var entries = fs.src(['test/fixtures/entry.js', 'test/fixtures/anotherentrypoint.js', 'test/fixtures/subdirectory/entry.js']);
+  var stream = webpack({
+    config: {},
+    quiet: true
+  });
+  stream.on('data', function (file) {
+    var basename = path.basename(file.path);
+    var contents = file.contents.toString();
+    switch (basename) {
+      case 'entry.js':
+        t.ok(/module\.exports = __webpack_require__/i.test(contents), 'should contain "module.exports = __webpack_require__"');
+        break;
+      case 'anotherentrypoint.js':
+        t.notOk(/module\.exports = __webpack_require__/i.test(contents), 'should not contain "module.exports = __webpack_require__"');
+        break;
+    }
+  });
+  entries.pipe(named()).pipe(stream);
+});
+
 test('empty input stream', function (t) {
   t.plan(1);
 


### PR DESCRIPTION
Hey,

Currently webpack-steam always passes files for named entry as an array. Because of that webpack is creating dummy module and all it does is requiring our main file, for example:
```javascript
/***/ 4:
/***/ (function(module, exports, __webpack_require__) {

module.exports = __webpack_require__(5);


/***/ }),
```
It is ugly and what's worse that module is does not receive id from `HashedModuleIdsPlugin` (that's what lead me to discovery of current behaviour). This PR fixes it by extracting first element from the array if the array has only one element.