### PR TITLE
Incorrect entry validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,27 @@ var defaultStatsOptions = {
   errorDetails: false
 };
 
+function validEntry(entry) {
+  if (!entry) {
+    return false;
+  }
+
+  // Arrays and strings
+  if (entry.length > 1) {
+    return true;
+  }
+
+  var type = typeof entry;
+
+  // Objects and promises
+  if (type === 'object' && !entry.then && Object.getOwnPropertyNames(entry)) {
+    return false;
+  }
+
+  // Functions
+  return type === 'function';
+}
+
 module.exports = function (options, wp, done) {
   options = clone(options) || {};
   var config = options.config || options;
@@ -106,7 +127,7 @@ module.exports = function (options, wp, done) {
       config.watch = options.watch;
       entry = [];
 
-      if (!config.entry || config.entry.length < 1) {
+      if (!validEntry(config.entry)) {
         gutil.log('webpack-stream - No files given; aborting compilation');
         self.emit('end');
         return false;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var defaultStatsOptions = {
   errorDetails: false
 };
 
-function validEntry(entry) {
+function validEntry (entry) {
   if (!entry) {
     return false;
   }


### PR DESCRIPTION
Using 'webpack' directly, you can supply strings, arrays, objects, promises, and functions to the `entry` config option. 'webpack-stream' only allows string and arrays.

This pull request expands the validation to include other types. The change breaks most of the tests at the moment. Not clear why, as I'm unfamiliar with the testing framework, which isn't giving me a lot of feedback.