### PR TITLE
Update Travis config: Remove node 0.10 and add latest node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - '0.10'
   - '4'
   - '6'
   - '8'
+  - 'node'
+  


### PR DESCRIPTION
Builds are currently [failing](https://travis-ci.org/shama/webpack-stream/builds/261894688) because of `0.10`.

Getting rid of `0.10` seems to be appropriate since it’s end-of-life since since 2016-10-31.
https://github.com/nodejs/Release#release-schedule

