### PR TITLE
Switch to supports-color over chalk

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var fancyLog = require('fancy-log');
 var PluginError = require('plugin-error');
-var chalk = require('chalk');
+var supportsColor = require('supports-color');
 var File = require('vinyl');
 var MemoryFileSystem = require('memory-fs');
 var nodePath = require('path');
@@ -12,7 +12,7 @@ var clone = require('lodash.clone');
 var some = require('lodash.some');
 
 var defaultStatsOptions = {
-  colors: chalk.supportsColor,
+  colors: supportsColor.stdout.hasBasic,
   hash: false,
   timings: false,
   chunks: false,
@@ -52,7 +52,7 @@ module.exports = function (options, wp, done) {
 
       if (options.verbose) {
         fancyLog(stats.toString({
-          colors: chalk.supportsColor
+          colors: supportsColor.stdout.hasBasic
         }));
       } else {
         var statsOptions = (options && options.stats) || {};

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     ]
   },
   "dependencies": {
-    "chalk": "^2.3.0",
+    "supports-color": "^5.2.0",
     "fancy-log": "^1.3.2",
     "lodash.clone": "^4.3.2",
     "lodash.some": "^4.2.2",


### PR DESCRIPTION
At some point, chalk.supportsColor changed so that it returns an object rather than a boolean or webpack changed so that it requires a boolean. This results in a `WebpackOptionsValidationError` error thrown after the first run of webpack-stream as it mutates the configuration option with it's defaults.

When trying to figure out if/what version of chalk made this change to check for backwards compatibility issues, I realised we don't use any other aspects of chalk, and given chalk uses supports-color to power supportsColor anyway it seemed to make sense to just use that dependancy directly.

This PR changes to support-color, and fixes the issue where an invalid object is passed into webpack's configuration if your own webpack.config.js doesn't contain stats.colors.
