### PR TITLE
Fix Webpack 4 deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,7 +176,11 @@ module.exports = function (options, wp, done) {
 
       var fs = compiler.outputFileSystem = new MemoryFileSystem();
 
-      compiler.plugin('after-emit', function (compilation, callback) {
+      var afterEmitPlugin = compiler.hooks ?
+        function (callback) { compiler.hooks.afterEmit.tapAsync('WebpackStream', callback); } : // Webpack 4
+        function (callback) { compiler.plugin('after-emit', callback); }; // Webpack 2/3
+
+      afterEmitPlugin(function (compilation, callback) {
         Object.keys(compilation.assets).forEach(function (outname) {
           if (compilation.assets[outname].emitted) {
             var file = prepareFile(fs, compiler, outname);


### PR DESCRIPTION
DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead

This change fixes the deprecation warning but ensure supports with both Webpack 2/3 & 4.