### PR TITLE
Separate errors with newlines.

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,10 +139,7 @@ module.exports = function (options, wp, done) {
       var jsonStats = stats ? stats.toJson() || {} : {};
       var errors = jsonStats.errors || [];
       if (errors.length) {
-        var errorMessage = errors.reduce(function (resultMessage, nextError) {
-          resultMessage += nextError.toString();
-          return resultMessage;
-        }, '');
+        var errorMessage = errors.join('\n');
         var compilationError = new PluginError('webpack-stream', errorMessage);
         if (!options.watch) {
           self.emit('error', compilationError);

--- a/test/fake-error-loader.js
+++ b/test/fake-error-loader.js
@@ -1,0 +1,10 @@
+module.exports = function fakeErrorLoader (text) {
+  this.cacheable();
+
+  var fakeError = new Error('Fake error');
+  // delete stack trace prevent it from showing up in webpack output
+  delete fakeError.stack;
+  this.emitError(fakeError);
+
+  return text;
+};

--- a/test/test.js
+++ b/test/test.js
@@ -152,3 +152,38 @@ test('no options', function (t) {
   });
   stream.end();
 });
+
+test('error formatting', function (t) {
+  t.plan(2);
+  var expectedMessage =
+    './test/fixtures/entry.js\n' +
+    'Fake error\n' +
+    './test/fixtures/one.js\n' +
+    'Fake error\n' +
+    ' @ ./test/fixtures/entry.js 3:10-29\n' +
+    './test/fixtures/chunk.js\n' +
+    'Fake error\n' +
+    ' @ ./test/fixtures/entry.js 4:0-6:2';
+  var entry = fs.src('test/fixtures/entry.js');
+  var stream = webpack({
+    quiet: true,
+    config: {
+      module: {
+        rules: [
+          {
+            test: /\.js$/,
+            enforce: 'pre',
+            use: './test/fake-error-loader'
+          }
+        ]
+      }
+    }
+  });
+  stream.on('error', function (err) {
+    t.equal(err.message, expectedMessage, 'error message');
+  });
+  stream.on('compilation-error', function (err) {
+    t.equal(err.message, expectedMessage, 'compilation-error message');
+  });
+  entry.pipe(stream);
+});


### PR DESCRIPTION
When emitting "error" and "compilation-error" events on the stream, underlying errors reported as `stats.errors` by Webpack were joined without newlines.  This could lead to error messages like these (taken from the build output of a project that uses `webpack-stream` and `ts-loader`):

```
[tsl] ERROR in D:\frontend\app\views\SampleView.ts(8,2)
      TS2564: Property '_parentEntity' has no initializer and is not definitely assigned in the constructor../app/views/SampleView.ts
[tsl] ERROR in D:\frontend\...
```

Note the absence of a newline before `../app/views/SampleView.ts`.

In this commit:
  1. Individual error messages are joined with `\n`.
  2. A `test('error formatting')` is added that checks error formatting using a fake Webpack loader producing some errors (`test/fake-error-loader.js`).