### PR TITLE
Adds webpack 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - '4'
   - '6'
   - '8'
   - 'node'
-  
+

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "http://dontkry.com"
   },
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 6.11.5"
   },
   "scripts": {
     "test": "semistandard && node test/test.js"
@@ -26,15 +26,15 @@
     ]
   },
   "dependencies": {
-    "supports-color": "^5.3.0",
     "fancy-log": "^1.3.2",
     "lodash.clone": "^4.3.2",
     "lodash.some": "^4.2.2",
     "memory-fs": "^0.4.1",
     "plugin-error": "^1.0.1",
+    "supports-color": "^5.3.0",
     "through": "^2.3.8",
     "vinyl": "^2.1.0",
-    "webpack": "^3.4.1"
+    "webpack": "^4.7.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",

--- a/test/test.js
+++ b/test/test.js
@@ -11,6 +11,7 @@ test('streams output assets', function (t) {
   var entry = fs.src('test/fixtures/entry.js');
   var stream = webpack({
     config: {
+      mode: 'development',
       output: {
         filename: 'bundle.js'
       }
@@ -37,6 +38,7 @@ test('multiple entry points', function (t) {
   t.plan(3);
   var stream = webpack({
     config: {
+      mode: 'development',
       entry: {
         'one': path.join(base, 'entry.js'),
         'two': path.join(base, 'anotherentrypoint.js')
@@ -67,7 +69,9 @@ test('stream multiple entry points', function (t) {
   t.plan(3);
   var entries = fs.src(['test/fixtures/entry.js', 'test/fixtures/anotherentrypoint.js']);
   var stream = webpack({
-    config: {},
+    config: {
+      mode: 'development'
+    },
     quiet: true
   });
   stream.on('data', function (file) {
@@ -113,6 +117,7 @@ test('multi-compile', function (t) {
   var stream = webpack({
     quiet: true,
     config: [{
+      mode: 'development',
       entry: {
         'one': path.join(base, 'entry.js')
       },
@@ -120,6 +125,7 @@ test('multi-compile', function (t) {
         filename: '[name].bundle.js'
       }
     }, {
+      mode: 'development',
       entry: {
         'two': path.join(base, 'anotherentrypoint.js')
       },


### PR DESCRIPTION
 - Updates Webpack to version 4 and fixes the unit tests.
 - Sets the engine to minimal version of 6.11.5, the same on Webpack 4.
 - Remove Node 4 from TravisCI settings

This PR keep Webpack as a project dependency since the webpack documentation says if you use this module you don't need to install webpack as a project dependency:
https://webpack.js.org/guides/integrations/#gulp
