### PR TITLE
Make webpack-stream agnostic of the webpack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "test": "semistandard && node test/test.js"
+    "test": "semistandard && npm-install-peers && node test/test.js"
   },
   "files": [
     "index.js"
@@ -33,16 +33,19 @@
     "memory-fs": "^0.4.1",
     "plugin-error": "^1.0.1",
     "through": "^2.3.8",
-    "vinyl": "^2.1.0",
-    "webpack": "^3.4.1"
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",
+    "npm-install-peers": "^1.2.1",
     "rimraf": "^2.4.4",
     "semistandard": "^12.0.1",
     "tape": "^4.9.0",
     "vinyl-fs": "^3.0.2",
     "vinyl-named": "^1.1.0"
+  },
+  "peerDependencies": {
+    "webpack": "*"
   },
   "keywords": [
     "gulpplugin",


### PR DESCRIPTION
The current implementation of `webpack-stream` forces developers to use the `webpack` version defined in the `package.json`. 
Realistically we can assume that this package will always be used in a context where its host have `webpack` as dependency. This is why we can leverage the [npm peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies/).

I added the package `install-peer-dependencies` so that we can run the unit tests even if the project is not embedded anywhere. 
I also decided not to add that to the `postinstall` npm hook because it is intended for development purposes only.

Those change bring up another problems though. The unit tests are very version dependant and about 80% of them are failing if we try running this with webpack 4. 

Not too sure what to do with those, I'd be happy to listen to your recommendation and update accordingly.
