### PR TITLE
fix missing type checking for statsOptions. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,9 +64,9 @@ module.exports = function (options, wp, done) {
             }
           });
         }
-        var statusLog
-        if (statusLog = stats.toString(statsOptions)) {
-          fancyLog(statusLog)
+        var statusLog = stats.toString(statsOptions);
+        if (statusLog) {
+          fancyLog(statusLog);
         }
       }
     };

--- a/index.js
+++ b/index.js
@@ -57,11 +57,13 @@ module.exports = function (options, wp, done) {
       } else {
         var statsOptions = (options && options.stats) || {};
 
-        Object.keys(defaultStatsOptions).forEach(function (key) {
-          if (typeof statsOptions[key] === 'undefined') {
-            statsOptions[key] = defaultStatsOptions[key];
-          }
-        });
+        if (typeof statsOptions === 'object') {
+          Object.keys(defaultStatsOptions).forEach(function (key) {
+            if (typeof statsOptions[key] === 'undefined') {
+              statsOptions[key] = defaultStatsOptions[key];
+            }
+          });
+        }
 
         fancyLog(stats.toString(statsOptions));
       }

--- a/index.js
+++ b/index.js
@@ -64,8 +64,10 @@ module.exports = function (options, wp, done) {
             }
           });
         }
-
-        fancyLog(stats.toString(statsOptions));
+        var statusLog
+        if (statusLog = stats.toString(statsOptions)) {
+          fancyLog(statusLog)
+        }
       }
     };
   }


### PR DESCRIPTION
webpack support stats options as  string, but only allow object here .

fix issuse: #185
reference: https://webpack.js.org/configuration/stats/
