### PR TITLE
Remove dependency to lodash.some

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var nodePath = require('path');
 var through = require('through');
 var ProgressPlugin = require('webpack/lib/ProgressPlugin');
 var clone = require('lodash.clone');
-var some = require('lodash.some');
 
 var defaultStatsOptions = {
   colors: supportsColor.stdout.hasBasic,
@@ -221,7 +220,7 @@ module.exports = function (options, wp, done) {
 
   // If entry point manually specified, trigger that
   var hasEntry = Array.isArray(config)
-    ? some(config, function (c) { return c.entry; })
+    ? config.some(function (c) { return c.entry; })
     : config.entry;
   if (hasEntry) {
     stream.end();


### PR DESCRIPTION
[`Array.prototype.some`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some) is implemented in all recent versions of node.js, so you can remove the dependency to `lodash.some`.

*I did not actually remove the dependency from `package.json`, just in case it's used elsewhere and I missed it. If you merge this PR, remember that the dependency should be removed.*