### PR TITLE
Fix issue 201 by moving cache to the function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,15 +26,13 @@ var defaultStatsOptions = {
   errorDetails: false
 };
 
-var cache = {};
+
 
 module.exports = function (options, wp, done) {
-  if (cache.wp !== wp || cache.options !== options) {
-    cache = {};
-  }
-
-  cache.options = options;
-  cache.wp = wp;
+  var cache = {
+    options: options,
+    wp: wp
+  };
 
   options = clone(options) || {};
   var config = options.config || options;

--- a/index.js
+++ b/index.js
@@ -26,8 +26,6 @@ var defaultStatsOptions = {
   errorDetails: false
 };
 
-
-
 module.exports = function (options, wp, done) {
   var cache = {
     options: options,


### PR DESCRIPTION
Fixing issue 201 by preventing cache.compiler from ever being the same instance for separately created instances of webpack-stream. This issue prevents webpack-stream from compiling the same file for multiple targets.