### PR TITLE
Added support for loading webpack config from file path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,10 @@ module.exports = function (options, wp, done) {
   options = clone(options) || {};
   var config = options.config || options;
 
+  if (typeof config === 'string') {
+    config = require(config);
+  }
+
   // Webpack 4 doesn't support the `quiet` attribute, however supports
   // setting `stats` to a string within an array of configurations
   // (errors-only|minimal|none|normal|verbose) or an object with an absurd

--- a/test/fixtures/webpack.config.js
+++ b/test/fixtures/webpack.config.js
@@ -1,0 +1,7 @@
+// Test config file for 'option file path' test.
+const config = {
+  input: './entry.js'
+  // input: './nope.js'
+};
+
+module.exports = config;

--- a/test/test.js
+++ b/test/test.js
@@ -159,6 +159,18 @@ test('no options', function (t) {
   stream.end();
 });
 
+test('config file path with webpack-stream options', function (t) {
+  t.plan(1);
+  var stream = webpack({
+    quiet: true,
+    config: path.join(base, 'webpack.config.js')
+  });
+  stream.on('end', function () {
+    t.ok(true, 'config successfully loaded from file, with webpack-stream options');
+  });
+  stream.end();
+});
+
 test('error formatting', function (t) {
   t.plan(2);
   // TODO: Fix this to test to rely less on large string outputs as those can change


### PR DESCRIPTION
This is useful for when using a typescript `gulpfile.ts` and when a dynamic import has to be truly dynamic. Since this is not possible within typescript. For instance you could do something like this:

```typescript
...
["a", "b", "c"].map(x => async () => 
  src("src/*.ts")
    .pipe(
      webpack({
        config: path.resolve(path.join(__dirname, x))
      })
      // or
      webpack(path.resolve(path.join(__dirname, x)))
    )
);
...
```

Obviously the example above is not that dynamic, but it gives you an idea of what could be. 

Anyway, with that said, the commit is probably not of best quality. There's definitely more. However, gives me something to work with. Discuss what you'd like to see more, and I can see what I can do. I thought of it as a start for now. 
